### PR TITLE
Misc cleanup

### DIFF
--- a/cores/rv32i/Makefile
+++ b/cores/rv32i/Makefile
@@ -18,6 +18,7 @@ SIM_DIR         := $(ROOT_DIR)/simulation
 SCRIPTS_DIR     := $(ROOT_DIR)/scripts
 LOG_DIR		    := $(ROOT_DIR)/log
 BINARIES_DIR    := $(ROOT_DIR)/bin
+DATA_DIR	    := $(ROOT_DIR)/data
 
 # Project's subdirectories
 # HDL exclusive source files
@@ -67,7 +68,7 @@ conf:
 sim_all: conf
 	@echo "Simulating all testbenches"
 	@$(VIVADO_CMD) -source $(SIMULATE_TCL) \
-		-tclargs $(language) $(HDL_DIR) $(SIM_SRC_DIR) $(WAVE_DIR) \
+		-tclargs $(language) $(HDL_DIR) $(SIM_SRC_DIR) $(DATA_DIR) $(WAVE_DIR) \
 		> $(LOG_DIR)/simulation_all.log 2>&1
 	@rm -rf *.backup.* vivado.jou
 	@echo "Simulations completed for $(project_name). Logs stored at $(LOG_DIR)/simulation_all.log; Waveforms stored at $(WAVE_DIR)"
@@ -77,7 +78,7 @@ sim_sel: conf
 	@echo "Simulating specific testbenches: $(TB)..."
 	@COMPILE_SRCS="$$(python3 $(DEP_ANALYZER) --lang $(language) --tbs "$${TB}" --hdl_dir $(HDL_DIR) --sim_dir $(SIM_SRC_DIR))" && \
 	cd $(WAVE_DIR) && $(VIVADO_CMD) -source $(SIMULATE_TCL) \
-		-tclargs $(language) "$${COMPILE_SRCS}" $(SIM_SRC_DIR) $(WAVE_DIR) $(TB) \
+		-tclargs $(language) "$${COMPILE_SRCS}" $(SIM_SRC_DIR) $(DATA_DIR) $(WAVE_DIR) $(TB) \
 		> $(LOG_DIR)/simulation_selected.log 2>&1
 	@rm -rf *.backup.* vivado.jou
 	@echo "Simulations completed for $(project_name): $(TB). Logs and waveforms stored in correspnding directories in $(LOG_DIR) and $(WAVE_DIR)"

--- a/cores/rv32i/scripts/simulate.tcl
+++ b/cores/rv32i/scripts/simulate.tcl
@@ -17,8 +17,9 @@
 set language    [lindex $argv 0]
 set compile_src [lindex $argv 1]
 set sim_src_dir [file normalize [lindex $argv 2]]
-set wave_dir    [file normalize [lindex $argv 3]]
-set tb_names    [lrange $argv 4 end]
+set data_dir    [file normalize [lindex $argv 3]]
+set wave_dir    [file normalize [lindex $argv 4]]
+set tb_names    [lrange $argv 5 end]
 
 # Determine HDL file extension
 if {$language eq "verilog"} {
@@ -83,21 +84,21 @@ foreach tb_file $tb_files {
     foreach src_file $design_files { 
         puts "Compiling source $src_file"
         if {$language eq "verilog"} {
-            exec xvlog $src_file -log "xvlog.log"
+            exec xvlog -define DATA_DIR="$data_dir/" $src_file -log "xvlog.log"
         } elseif {$language eq "vhdl"} {
             exec xvhdl $src_file -log "xvhdl.log"
         } elseif {$language eq "systemverilog"} {
-            exec xvlog -sv $src_file -log "xvlog.log"
+            exec xvlog -define DATA_DIR="$data_dir/" -sv $src_file -log "xvlog.log"
         }
     }
 
     puts "Compiling testbench $tb_file"
     if {$language eq "verilog"} {
-        exec xvlog $tb_file -log "xvlog.log"
+        exec xvlog -define DATA_DIR="$data_dir/" $tb_file -log "xvlog.log"
     } elseif {$language eq "vhdl"} {
         exec xvhdl $tb_file -log "xvhdl.log"
     } elseif {$language eq "systemverilog"} {
-        exec xvlog -sv $tb_file -log "xvlog.log"
+        exec xvlog -define DATA_DIR="$data_dir/" -sv $tb_file -log "xvlog.log"
     }
 
     # Elaborate

--- a/cores/rv32i/src/hdl/riscv_cpu.v
+++ b/cores/rv32i/src/hdl/riscv_cpu.v
@@ -203,7 +203,7 @@ module riscv_cpu(
 
     wire [3:0]             byte_enb;
     wire [`DATA_WIDTH-1:0] mem_write_data;
-    load LOAD_STORE_DECODER(
+    load_store_decoder LOAD_STORE_DECODER(
         .alu_result_addr(alu_results),
         .func3(func3),
         .reg_read(rs2),
@@ -217,7 +217,7 @@ module riscv_cpu(
         .clk(clk),
         .rst(rst),
         // Write ports inputs
-        .w_addr({alu_result[31:2], 2'b00}),
+        .w_addr({alu_results[31:2], 2'b00}),
         .w_dat(mem_write_data),
         .w_enb(mem_write),
         .byte_enb(byte_enb),

--- a/cores/rv32i/src/include/rv32i_params.vh
+++ b/cores/rv32i/src/include/rv32i_params.vh
@@ -12,8 +12,16 @@
 `define I_BRAM_DEPTH      1024           // Instruction BRAM depth
 `define BYTES_PER_WORD    4              // Each 32-bit word contains 4 bytes
 
+// DATA_DIR points to the location of the data folder.
+// Since in Vivado xsim, relative paths are interpreted relative to its
+// "xsim.dir" rather than the file's location, DATA_DIR needs to be set using a
+// -define directive in xvlog (part of simulate.tcl).
+`ifndef DATA_DIR
+`define DATA_DIR "../../data/"
+`endif
+
 // Testbench
 // relative paths for hex files
-`define RISCV_PROGRAMS    "../../../data/"
+`define RISCV_PROGRAMS    `DATA_DIR
 
 `endif

--- a/cores/rv32i/src/sim/bram32_tb.v
+++ b/cores/rv32i/src/sim/bram32_tb.v
@@ -59,6 +59,7 @@ module bram32_tb(
         .w_addr(w_addr),
         .w_dat(w_dat),
         .w_enb(w_enb),
+        // TODO missing byte_enb
         // Read ports inputs
         .r_addr(r_addr),
         .r_enb(r_enb),
@@ -88,7 +89,7 @@ module bram32_tb(
         r_addr = 32'h0;
         
         // Load .hex file into init_mem
-        $readmemh("add_registers.new.hex", init_mem);
+        $readmemh({`RISCV_PROGRAMS, "r_type/add_registers.new.hex"}, init_mem);
         
         // Deassert reset and initialize BRAM
         rst = 1'b0; 

--- a/cores/rv32i/src/sim/i_type_alu_addi_tb.v
+++ b/cores/rv32i/src/sim/i_type_alu_addi_tb.v
@@ -321,10 +321,10 @@ module i_type_alu_addi_tb(
         #10;
         
         // Loading data into data BRAM
-        $readmemh({`RISCV_PROGRAMS, "i_type/addi_instruction_test_data.hex"}, init_mem_data);
+        $readmemh({`RISCV_PROGRAMS, "i_alu_type/addi_instruction_test_data.hex"}, init_mem_data);
         // Loading program into instruction BRAM
         // $readmemh("beq_bne_instructions_test.new.hex", init_mem_instr);
-        $readmemh({`RISCV_PROGRAMS, "i_type/addi_instruction_test.new.hex"}, init_mem_instr);
+        $readmemh({`RISCV_PROGRAMS, "i_alu_type/addi_instruction_test.new.hex"}, init_mem_instr);
         
         // Deassert reset and initialize data BRAM
         rst = 1'b0; 

--- a/cores/rv32i/src/sim/pc_ibram_integration_tb.v
+++ b/cores/rv32i/src/sim/pc_ibram_integration_tb.v
@@ -78,6 +78,7 @@ module pc_ibram_integration_tb(
         .w_addr(w_addr),
         .w_dat(w_dat),
         .w_enb(w_enb),
+        .byte_enb(4'b1111),
         // Read ports inputs
         .r_addr(pc_out),
         .r_enb(r_enb),
@@ -108,7 +109,7 @@ module pc_ibram_integration_tb(
         #10;
         
         // Load .hex file into init_mem
-        $readmemh("add_registers.new.hex", init_mem);
+        $readmemh({`RISCV_PROGRAMS, "r_type/add_registers.new.hex"}, init_mem);
         
         // Deassert reset and initialize BRAM
         rst = 1'b0; 

--- a/cores/rv32i/src/sim/pc_ibram_integration_tb.v
+++ b/cores/rv32i/src/sim/pc_ibram_integration_tb.v
@@ -68,8 +68,7 @@ module pc_ibram_integration_tb(
         .stall(pc_stall),
         .pc_select(1'b0),
         .pc_in(`BOOT_ADDR),
-        .pc_out(pc_out),
-        .pc_next()
+        .pc_out(pc_out)
     );
     
     bram32 I_MEM(

--- a/cores/rv32i/src/sim/r_type_add_tb.v
+++ b/cores/rv32i/src/sim/r_type_add_tb.v
@@ -323,7 +323,7 @@ module r_type_add_tb(
         // Loading data into data BRAM
         $readmemh({`RISCV_PROGRAMS, "r_type/add_instruction_test_data.hex"}, init_mem_data);
         // Loading program into instruction BRAM
-        $readmemh({`RISCV_PROGRAMS, "add_instruction_test.new.hex"}, init_mem_instr);
+        $readmemh({`RISCV_PROGRAMS, "r_type/add_instruction_test.new.hex"}, init_mem_instr);
         
         // Deassert reset and initialize data BRAM
         rst = 1'b0; 

--- a/cores/rv32i/src/sim/self_dep_add_hazard_trigger_tb.v
+++ b/cores/rv32i/src/sim/self_dep_add_hazard_trigger_tb.v
@@ -68,6 +68,7 @@ module self_dep_add_hazard_trigger_tb(
         .w_addr(i_w_addr),
         .w_dat(i_w_dat),
         .w_enb(i_w_enb),
+        .byte_enb(4'b1111),
         // Read ports inputs
         .r_addr(pc_out),
         .r_enb(i_r_enb),
@@ -185,6 +186,7 @@ module self_dep_add_hazard_trigger_tb(
         .w_addr(d_bram_init_done ? alu_results : d_w_addr),
         .w_dat(d_bram_init_done  ? rs2         : d_w_dat),
         .w_enb(d_bram_init_done  ? mem_write   : d_w_enb),
+        .byte_enb(4'b1111),
         // Read ports inputs
         .r_addr(alu_results),
         .r_enb(mem_read), 
@@ -249,9 +251,9 @@ module self_dep_add_hazard_trigger_tb(
         #10;
         
         // Loading data into data BRAM
-        $readmemh("self_dep_test_data.hex", init_mem_data);
+        $readmemh({`RISCV_PROGRAMS, "hazards/self_dep_test_data.hex"}, init_mem_data);
         // Loading program into instruction BRAM
-        $readmemh("self_dep_add_test.new.hex", init_mem_instr);
+        $readmemh({`RISCV_PROGRAMS, "hazards/self_dep_add_test.new.hex"}, init_mem_instr);
         
         // Deassert reset and initialize data BRAM
         rst = 1'b0; 

--- a/cores/rv32i/src/sim/self_dep_add_hazard_trigger_tb.v
+++ b/cores/rv32i/src/sim/self_dep_add_hazard_trigger_tb.v
@@ -57,8 +57,7 @@ module self_dep_add_hazard_trigger_tb(
         .stall(pc_stall),
         .pc_select(1'b0),
         .pc_in(`BOOT_ADDR),
-        .pc_out(pc_out),
-        .pc_next()
+        .pc_out(pc_out)
     );
     
     wire [`DATA_WIDTH-1:0] instruction;

--- a/cores/rv32i/src/sim/self_dep_hazard_trigger_tb.v
+++ b/cores/rv32i/src/sim/self_dep_hazard_trigger_tb.v
@@ -66,6 +66,7 @@ module self_dep_hazard_trigger_tb(
         .w_addr(i_w_addr),
         .w_dat(i_w_dat),
         .w_enb(i_w_enb),
+        .byte_enb(4'b1111),
         // Read ports inputs
         .r_addr(pc_out),
         .r_enb(i_r_enb),
@@ -183,6 +184,7 @@ module self_dep_hazard_trigger_tb(
         .w_addr(d_bram_init_done ? alu_results : d_w_addr),
         .w_dat(d_bram_init_done  ? rs2         : d_w_dat),
         .w_enb(d_bram_init_done  ? mem_write   : d_w_enb),
+        .byte_enb(4'b1111),
         // Read ports inputs
         .r_addr(alu_results),
         .r_enb(mem_read), 
@@ -247,9 +249,9 @@ module self_dep_hazard_trigger_tb(
         #10;
         
         // Loading data into data BRAM
-        $readmemh("self_dep_test_data.hex", init_mem_data);
+        $readmemh({`RISCV_PROGRAMS, "hazards/self_dep_test_data.hex"}, init_mem_data);
         // Loading program into instruction BRAM
-        $readmemh("self_dep_test.new.hex", init_mem_instr);
+        $readmemh({`RISCV_PROGRAMS, "hazards/self_dep_test.new.hex"}, init_mem_instr);
         
         // Deassert reset and initialize data BRAM
         rst = 1'b0; 

--- a/cores/rv32i/src/sim/self_dep_hazard_trigger_tb.v
+++ b/cores/rv32i/src/sim/self_dep_hazard_trigger_tb.v
@@ -55,8 +55,7 @@ module self_dep_hazard_trigger_tb(
         .stall(pc_stall),
         .pc_select(1'b0),
         .pc_in(`BOOT_ADDR),
-        .pc_out(pc_out),
-        .pc_next()
+        .pc_out(pc_out)
     );
     
     wire [`DATA_WIDTH-1:0] instruction;

--- a/cores/rv32i/src/sim/shift_instructions_tb.v
+++ b/cores/rv32i/src/sim/shift_instructions_tb.v
@@ -117,7 +117,7 @@ module shift_instructions_tb(
         .alu_src(alu_src),
         .reg_write(reg_write),
         .wrt_back_src(wrt_back_src),
-        .second_u_type_add_src(second_u_type_add_src)
+        .second_add_src(second_u_type_add_src)
     );
     
     // Register file


### PR DESCRIPTION
Some small cleanups and fixes:

[Pass data_dir as absolute path](https://github.com/szymek1/RISCV-Research-Project/commit/a87b1598b1bdd8e08f1850ee2ea6fca38b67b398)
- The previous relative path was relative to xsim.dir rather than the file's location. Using absolute paths here is less confusing and more flexible 

[Fix errors](https://github.com/szymek1/RISCV-Research-Project/commit/f875ffc8a60eb7a9f92cc35d4bb5cf61b2e0b853)
- Some variable/module/port names had typos or did not exist anymore
- sim_all completes successfully now

[Fix readmemh paths](https://github.com/szymek1/RISCV-Research-Project/pull/3/commits/136f8d90cf9eff9384f0f7a95a02eab28abf081e)
- In some testbenches the paths to the hex files were wrong