### PR TITLE
Add iverilog

### DIFF
--- a/cores/rv32i/Makefile
+++ b/cores/rv32i/Makefile
@@ -21,17 +21,9 @@ BINARIES_DIR    := $(ROOT_DIR)/bin
 DATA_DIR	    := $(ROOT_DIR)/data
 
 # Project's subdirectories
-# HDL exclusive source files
 HDL_DIR 	    := $(SOURCE_DIR)/hdl
-
-# testbenches
 SIM_SRC_DIR     := $(SOURCE_DIR)/sim
-
-# constraints
 CONSTRAINTS_DIR := $(SOURCE_DIR)/constraints
-
-# Waveforms
-WAVE_DIR 	    := $(SIM_DIR)/waveforms
 
 # Netlist and bitstream
 NETLIST_DIR     := $(BINARIES_DIR)/netlist
@@ -53,37 +45,64 @@ device 		    := xc7z020clg400-1
 
 VIVADO_CMD 		:= vivado -mode batch
 
-# Directories to verify during configuration directive
-DIRS := $(HDL_DIR) $(CONSTRAINTS_DIR) $(SIM_SRC_DIR) $(WAVE_DIR) \
-        $(NETLIST_DIR) $(BITSTREAM_DIR) $(LOG_DIR)
+IVERILOG_FLAGS := -g2012 -Wall
 
-.PHONY: conf sim_all sim_sel bit program_fpga clean
+ALL_TB_SRC := $(wildcard $(SIM_SRC_DIR)/*_tb.v)
+ALL_TB := $(ALL_TB_SRC:$(SIM_SRC_DIR)/%.v=%)
+ALL_TB_REPORT := $(ALL_TB:%=$(SIM_DIR)/%.txt)
 
-conf:
-	@echo "Checking and creating necessary directories..."
-	@mkdir -p $(DIRS)
-	@echo "Directories ensured."
+# Build TB and output convert dependencies to Makefile .d format
+$(BINARIES_DIR)/vvp/%.vvp: $(SIM_SRC_DIR)/%.v
+	@echo "Compiling $(@F:.vvp=)"
+	mkdir -p $(@D)
+	iverilog $(IVERILOG_FLAGS) \
+		-Mall=$(@:.vvp=.d.raw) -y $(HDL_DIR) -I $(<D) \
+		-DDATA_DIR=\"$(DATA_DIR)/\" \
+		-o $@ $<
+	@{ \
+	  printf '%s:' '$@'; \
+	  sort -u $(@:.vvp=.d.raw) | tr '\n' ' '; \
+	  printf '\n'; \
+	} > $(@:.vvp=.d)
+	@rm $(@:.vvp=.d.raw)
 
-# Run all testbenches
-sim_all: conf
+# Run TB and output report
+$(SIM_DIR)/%/sim_output.txt: $(BINARIES_DIR)/vvp/%.vvp
+	mkdir -p $(@D)
+	@echo "Running $(<F:.vvp=)"
+	vvp $< | tee $@
+
+# Alias each tb name to its report
+$(ALL_TB): %: $(SIM_DIR)/%/sim_output.txt
+
+# Target that combines all TBs
+.PHONY: sim
+sim: $(ALL_TB)
+
+#
+# ================ VIVADO ================
+#
+
+# - Run all testbenches: example $ make sim-vivado
+# - Run selected testbenches: example $ make sim-vivado TB="tb1 tb2 tb3" USE "...", no need for file extension
+.PHONY: sim-vivado
+sim-vivado:
+	mkdir -p $(SIM_DIR) $(LOG_DIR)
+ifeq ($(TB),)
 	@echo "Simulating all testbenches"
-	@$(VIVADO_CMD) -source $(SIMULATE_TCL) \
-		-tclargs $(language) $(HDL_DIR) $(SIM_SRC_DIR) $(DATA_DIR) $(WAVE_DIR) \
-		> $(LOG_DIR)/simulation_all.log 2>&1
-	@rm -rf *.backup.* vivado.jou
-	@echo "Simulations completed for $(project_name). Logs stored at $(LOG_DIR)/simulation_all.log; Waveforms stored at $(WAVE_DIR)"
-
-# Run selected testbenches: example $ make sim_sel TB="tb1 tb2 tb3" USE "...", no need for file extension
-sim_sel: conf
+else
 	@echo "Simulating specific testbenches: $(TB)..."
-	@COMPILE_SRCS="$$(python3 $(DEP_ANALYZER) --lang $(language) --tbs "$${TB}" --hdl_dir $(HDL_DIR) --sim_dir $(SIM_SRC_DIR))" && \
-	cd $(WAVE_DIR) && $(VIVADO_CMD) -source $(SIMULATE_TCL) \
-		-tclargs $(language) "$${COMPILE_SRCS}" $(SIM_SRC_DIR) $(DATA_DIR) $(WAVE_DIR) $(TB) \
-		> $(LOG_DIR)/simulation_selected.log 2>&1
+endif
+	@$(VIVADO_CMD) -source $(SIMULATE_TCL) \
+		-tclargs $(language) $(HDL_DIR) $(SIM_SRC_DIR) $(DATA_DIR) $(SIM_DIR) $(TB) \
+		> $(LOG_DIR)/sim.log 2>&1
 	@rm -rf *.backup.* vivado.jou
-	@echo "Simulations completed for $(project_name): $(TB). Logs and waveforms stored in correspnding directories in $(LOG_DIR) and $(WAVE_DIR)"
+	@echo "Simulations completed for $(project_name). Logs stored at $(LOG_DIR)/sim.log; Simulation output stored at $(SIM_DIR)"
 
-bit: conf
+.PHONY: bit
+bit: $(BITSTREAM_DIR)/$(project_name).bit
+$(BITSTREAM_DIR)/$(project_name).bit:
+	mkdir -p $(NETLIST_DIR) $(BITSTREAM_DIR) $(LOG_DIR)
 	@echo "Building bitstream..."
 	@$(VIVADO_CMD) -source $(BUILD_TCL) \
 		-tclargs $(language) $(HDL_DIR) $(CONSTRAINTS_DIR) $(NETLIST_DIR) $(BITSTREAM_DIR) $(device) $(project_name) $(top_module) \
@@ -91,6 +110,7 @@ bit: conf
 	@rm -rf *.backup.* vivado.jou
 	@echo "Build completed for $(project_name). Logs stored at $(LOG_DIR)/build.log"
 
+.PHONY: program_fpga
 program_fpga: bit
 	@echo "Programming FPGA..."
 	@$(VIVADO_CMD) -source $(PROGRAM_TCL) \
@@ -99,7 +119,16 @@ program_fpga: bit
 	@rm -rf *.backup.* vivado.jou
 	@echo "FPGA programmed for $(project_name). Logs stored at $(LOG_DIR)/program.log"
 
+
+#
+# ================ VIVADO ================
+#
+
+.PHONY: clean
 clean:
 	@echo "Cleaning generated files..."
-	@rm -rf $(BINARIES_DIR)/* $(LOG_DIR)/* *.backup.* vivado.jou
+	@rm -rf $(BINARIES_DIR) $(LOG_DIR) $(SIM_DIR) *.backup.* vivado.jou vivado.log
 	@echo "Clean completed."
+
+# Pull in previously generated .d dependency files
+-include $(wildcard $(BINARIES_DIR)/vvp/*.d)

--- a/cores/rv32i/Makefile
+++ b/cores/rv32i/Makefile
@@ -26,6 +26,8 @@ SIM_SRC_DIR     := $(SOURCE_DIR)/sim
 CONSTRAINTS_DIR := $(SOURCE_DIR)/constraints
 
 # Netlist and bitstream
+VVP_DIR     := $(BINARIES_DIR)/vvp
+D_DIR   := $(BINARIES_DIR)/d
 NETLIST_DIR     := $(BINARIES_DIR)/netlist
 BITSTREAM_DIR   := $(BINARIES_DIR)/bit
 
@@ -51,26 +53,31 @@ ALL_TB_SRC := $(wildcard $(SIM_SRC_DIR)/*_tb.v)
 ALL_TB := $(ALL_TB_SRC:$(SIM_SRC_DIR)/%.v=%)
 ALL_TB_REPORT := $(ALL_TB:%=$(SIM_DIR)/%.txt)
 
+#
+# ================ IVERILOG ================
+#
+
 # Build TB and output convert dependencies to Makefile .d format
-$(BINARIES_DIR)/vvp/%.vvp: $(SIM_SRC_DIR)/%.v
-	@echo "Compiling $(@F:.vvp=)"
-	mkdir -p $(@D)
-	iverilog $(IVERILOG_FLAGS) \
+.PRECIOUS: $(VVP_DIR)/%.vvp
+$(VVP_DIR)/%.vvp: $(SIM_SRC_DIR)/%.v
+	@echo "Compiling testbench \"$(@F:.vvp=)\""
+	@mkdir -p $(VVP_DIR) $(D_DIR) $(LOG_DIR)
+	@iverilog $(IVERILOG_FLAGS) \
 		-Mall=$(@:.vvp=.d.raw) -y $(HDL_DIR) -I $(<D) \
 		-DDATA_DIR=\"$(DATA_DIR)/\" \
-		-o $@ $<
+		-o $@ $< > $(LOG_DIR)/compile_$(@F:.vvp=).txt 2>&1
 	@{ \
 	  printf '%s:' '$@'; \
 	  sort -u $(@:.vvp=.d.raw) | tr '\n' ' '; \
 	  printf '\n'; \
-	} > $(@:.vvp=.d)
+	} > $(@:$(VVP_DIR)/%.vvp=$(D_DIR)/%.d)
 	@rm $(@:.vvp=.d.raw)
 
 # Run TB and output report
-$(SIM_DIR)/%/sim_output.txt: $(BINARIES_DIR)/vvp/%.vvp
-	mkdir -p $(@D)
-	@echo "Running $(<F:.vvp=)"
-	vvp $< | tee $@
+$(SIM_DIR)/%/sim_output.txt: $(VVP_DIR)/%.vvp
+	@mkdir -p $(@D)
+	@echo "Running testbench \"$(<F:.vvp=)\""
+	@cd $(@D) && vvp $< > $@ 2>&1
 
 # Alias each tb name to its report
 $(ALL_TB): %: $(SIM_DIR)/%/sim_output.txt
@@ -121,7 +128,7 @@ program_fpga: bit
 
 
 #
-# ================ VIVADO ================
+# ================ MISC ================
 #
 
 .PHONY: clean
@@ -131,4 +138,4 @@ clean:
 	@echo "Clean completed."
 
 # Pull in previously generated .d dependency files
--include $(wildcard $(BINARIES_DIR)/vvp/*.d)
+-include $(wildcard $(D_DIR)/*.d)

--- a/cores/rv32i/Makefile
+++ b/cores/rv32i/Makefile
@@ -18,6 +18,7 @@ SIM_DIR         := $(ROOT_DIR)/simulation
 SCRIPTS_DIR     := $(ROOT_DIR)/scripts
 LOG_DIR		    := $(ROOT_DIR)/log
 BINARIES_DIR    := $(ROOT_DIR)/bin
+DATA_DIR	    := $(ROOT_DIR)/data
 
 # Project's subdirectories
 # HDL exclusive source files
@@ -67,7 +68,7 @@ conf:
 sim_all: conf
 	@echo "Simulating all testbenches"
 	@$(VIVADO_CMD) -source $(SIMULATE_TCL) \
-		-tclargs $(language) $(HDL_DIR) $(SIM_SRC_DIR) $(WAVE_DIR) \
+		-tclargs $(language) $(HDL_DIR) $(SIM_SRC_DIR) $(DATA_DIR) $(WAVE_DIR) \
 		> $(LOG_DIR)/simulation_all.log 2>&1
 	@rm -rf *.backup.* vivado.jou
 	@echo "Simulations completed for $(project_name). Logs stored at $(LOG_DIR)/simulation_all.log; Waveforms stored at $(WAVE_DIR)"
@@ -77,7 +78,7 @@ sim_sel: conf
 	@echo "Simulating specific testbenches: $(TB)..."
 	@COMPILE_SRCS="$$(python3 $(DEP_ANALYZER) --lang $(language) --tbs "$${TB}" --hdl_dir $(HDL_DIR) --sim_dir $(SIM_SRC_DIR))" && \
 	cd $(WAVE_DIR) && $(VIVADO_CMD) -source $(SIMULATE_TCL) \
-		-tclargs $(language) "$${COMPILE_SRCS}" $(SIM_SRC_DIR) $(WAVE_DIR) $(TB) \
+		-tclargs $(language) "$${COMPILE_SRCS}" $(SIM_SRC_DIR) $(DATA_DIR) $(WAVE_DIR) $(TB) \
 		> $(LOG_DIR)/simulation_selected.log 2>&1
 	@rm -rf *.backup.* vivado.jou
 	@echo "Simulations completed for $(project_name): $(TB). Logs and waveforms stored in correspnding directories in $(LOG_DIR) and $(WAVE_DIR)"

--- a/cores/rv32i/scripts/simulate.tcl
+++ b/cores/rv32i/scripts/simulate.tcl
@@ -17,8 +17,9 @@
 set language    [lindex $argv 0]
 set compile_src [lindex $argv 1]
 set sim_src_dir [file normalize [lindex $argv 2]]
-set wave_dir    [file normalize [lindex $argv 3]]
-set tb_names    [lrange $argv 4 end]
+set data_dir    [file normalize [lindex $argv 3]]
+set wave_dir    [file normalize [lindex $argv 4]]
+set tb_names    [lrange $argv 5 end]
 
 # Determine HDL file extension
 if {$language eq "verilog"} {
@@ -83,21 +84,21 @@ foreach tb_file $tb_files {
     foreach src_file $design_files { 
         puts "Compiling source $src_file"
         if {$language eq "verilog"} {
-            exec xvlog $src_file -log "xvlog.log"
+            exec xvlog -define DATA_DIR="$data_dir/" $src_file -log "xvlog.log"
         } elseif {$language eq "vhdl"} {
             exec xvhdl $src_file -log "xvhdl.log"
         } elseif {$language eq "systemverilog"} {
-            exec xvlog -sv $src_file -log "xvlog.log"
+            exec xvlog -define DATA_DIR="$data_dir/" -sv $src_file -log "xvlog.log"
         }
     }
 
     puts "Compiling testbench $tb_file"
     if {$language eq "verilog"} {
-        exec xvlog $tb_file -log "xvlog.log"
+        exec xvlog -define DATA_DIR="$data_dir/" $tb_file -log "xvlog.log"
     } elseif {$language eq "vhdl"} {
         exec xvhdl $tb_file -log "xvhdl.log"
     } elseif {$language eq "systemverilog"} {
-        exec xvlog -sv $tb_file -log "xvlog.log"
+        exec xvlog -define DATA_DIR="$data_dir/" -sv $tb_file -log "xvlog.log"
     }
 
     # Elaborate

--- a/cores/rv32i/src/hdl/byte_reader.v
+++ b/cores/rv32i/src/hdl/byte_reader.v
@@ -35,7 +35,7 @@ module byte_reader (
     reg [`DATA_WIDTH-1:0] masked_data;
     reg [`DATA_WIDTH-1:0] shifted_data;
 
-    // masking data according to bye mask
+    // masking data according to byte mask
     integer i;
     always @(*) begin
         for (i = 0; i < 4; i = i + 1) begin

--- a/cores/rv32i/src/hdl/control.v
+++ b/cores/rv32i/src/hdl/control.v
@@ -44,7 +44,7 @@ module control(
     );
     
     /*
-    TODO: allow for full clock synchornization, probably during swithcing to a pipelined version
+    TODO: allow for full clock synchronization, probably during switching to a pipelined version
           where intermediate registers will need to handle 1 clock delays.
     */
     reg [1:0] alu_op;

--- a/cores/rv32i/src/hdl/register_file.v
+++ b/cores/rv32i/src/hdl/register_file.v
@@ -37,7 +37,7 @@ module register_file(
     // WRITE
     input  wire                         write_enable,
     input  wire [`REG_ADDR_WIDTH-1:0]   write_addr, // specifies which register to write to
-    input  wire [`DATA_WIDTH-1:0]       write_data  // value to wrtie
+    input  wire [`DATA_WIDTH-1:0]       write_data  // value to write
     
     );
     

--- a/cores/rv32i/src/hdl/riscv_cpu.v
+++ b/cores/rv32i/src/hdl/riscv_cpu.v
@@ -32,7 +32,7 @@ module riscv_cpu(
     wire [`DATA_WIDTH-1:0]  pc_plus_4;       // used for returning from a jump
     wire                    branch;          // provided by control module- branch decoder
     wire [`INSTR_WIDTH-1:0] immediate;       // provided by sign_extend module
-    reg  [`INSTR_WIDTH-1:0] pc_plus_sec_src; // provided by sequentail block, which 
+    reg  [`INSTR_WIDTH-1:0] pc_plus_sec_src; // provided by sequential block, which 
                                              // decodes second_add_src from control module
 
     pc PC(
@@ -127,7 +127,7 @@ module riscv_cpu(
     reg                    wb_valid;    // has to be set high after every write back operation
     
     // Block dedicated to deciding what should be the output to write back to register file.
-    // It changes accordingly to a current instruction: reading from data BRAM, register-to-tegister
+    // It changes accordingly to a current instruction: reading from data BRAM, register-to-register
     // or saving pc before the jump.
     wire [`INSTR_WIDTH-1:0]    alu_results;
     reg  [`DATA_WIDTH-1:0]     wrt_back_data;
@@ -154,8 +154,8 @@ module riscv_cpu(
     
     // Block dedicated U-Type instruction handling.
     // Regfile will be updated with a value either:
-    // lui  : immediate 20 bits shited left by 12
-    // auipc: immediate 20 bits shited left by 12 + current pc
+    // lui  : immediate 20 bits shifted left by 12
+    // auipc: immediate 20 bits shifted left by 12 + current pc
     // jalr : sign-extended 12-bit imm12 to the register rs1
     always @(*) begin
         case (second_add_src)

--- a/cores/rv32i/src/hdl/riscv_cpu.v
+++ b/cores/rv32i/src/hdl/riscv_cpu.v
@@ -203,7 +203,7 @@ module riscv_cpu(
 
     wire [3:0]             byte_enb;
     wire [`DATA_WIDTH-1:0] mem_write_data;
-    load LOAD_STORE_DECODER(
+    load_store_decoder LOAD_STORE_DECODER(
         .alu_result_addr(alu_results),
         .func3(func3),
         .reg_read(rs2),
@@ -217,7 +217,7 @@ module riscv_cpu(
         .clk(clk),
         .rst(rst),
         // Write ports inputs
-        .w_addr({alu_result[31:2], 2'b00}),
+        .w_addr({alu_results[31:2], 2'b00}),
         .w_dat(mem_write_data),
         .w_enb(mem_write),
         .byte_enb(byte_enb),

--- a/cores/rv32i/src/include/rv32i_params.vh
+++ b/cores/rv32i/src/include/rv32i_params.vh
@@ -12,8 +12,16 @@
 `define I_BRAM_DEPTH      1024           // Instruction BRAM depth
 `define BYTES_PER_WORD    4              // Each 32-bit word contains 4 bytes
 
+// DATA_DIR points to the location of the data folder.
+// Since in Vivado xsim, relative paths are interpreted relative to its
+// "xsim.dir" rather than the file's location, DATA_DIR needs to be set using a
+// -define directive in xvlog (part of simulate.tcl).
+`ifndef DATA_DIR
+`define DATA_DIR "../../data/"
+`endif
+
 // Testbench
 // relative paths for hex files
-`define RISCV_PROGRAMS    "../../../data/"
+`define RISCV_PROGRAMS    `DATA_DIR
 
 `endif

--- a/cores/rv32i/src/sim/bram32_tb.v
+++ b/cores/rv32i/src/sim/bram32_tb.v
@@ -59,6 +59,7 @@ module bram32_tb(
         .w_addr(w_addr),
         .w_dat(w_dat),
         .w_enb(w_enb),
+        // TODO missing byte_enb
         // Read ports inputs
         .r_addr(r_addr),
         .r_enb(r_enb),
@@ -88,7 +89,7 @@ module bram32_tb(
         r_addr = 32'h0;
         
         // Load .hex file into init_mem
-        $readmemh("add_registers.new.hex", init_mem);
+        $readmemh({`RISCV_PROGRAMS, "r_type/add_registers.new.hex"}, init_mem);
         
         // Deassert reset and initialize BRAM
         rst = 1'b0; 

--- a/cores/rv32i/src/sim/i_type_alu_addi_tb.v
+++ b/cores/rv32i/src/sim/i_type_alu_addi_tb.v
@@ -321,10 +321,10 @@ module i_type_alu_addi_tb(
         #10;
         
         // Loading data into data BRAM
-        $readmemh({`RISCV_PROGRAMS, "i_type/addi_instruction_test_data.hex"}, init_mem_data);
+        $readmemh({`RISCV_PROGRAMS, "i_alu_type/addi_instruction_test_data.hex"}, init_mem_data);
         // Loading program into instruction BRAM
         // $readmemh("beq_bne_instructions_test.new.hex", init_mem_instr);
-        $readmemh({`RISCV_PROGRAMS, "i_type/addi_instruction_test.new.hex"}, init_mem_instr);
+        $readmemh({`RISCV_PROGRAMS, "i_alu_type/addi_instruction_test.new.hex"}, init_mem_instr);
         
         // Deassert reset and initialize data BRAM
         rst = 1'b0; 

--- a/cores/rv32i/src/sim/pc_ibram_integration_tb.v
+++ b/cores/rv32i/src/sim/pc_ibram_integration_tb.v
@@ -78,6 +78,7 @@ module pc_ibram_integration_tb(
         .w_addr(w_addr),
         .w_dat(w_dat),
         .w_enb(w_enb),
+        .byte_enb(4'b1111),
         // Read ports inputs
         .r_addr(pc_out),
         .r_enb(r_enb),
@@ -108,7 +109,7 @@ module pc_ibram_integration_tb(
         #10;
         
         // Load .hex file into init_mem
-        $readmemh("add_registers.new.hex", init_mem);
+        $readmemh({`RISCV_PROGRAMS, "r_type/add_registers.new.hex"}, init_mem);
         
         // Deassert reset and initialize BRAM
         rst = 1'b0; 

--- a/cores/rv32i/src/sim/pc_ibram_integration_tb.v
+++ b/cores/rv32i/src/sim/pc_ibram_integration_tb.v
@@ -68,8 +68,7 @@ module pc_ibram_integration_tb(
         .stall(pc_stall),
         .pc_select(1'b0),
         .pc_in(`BOOT_ADDR),
-        .pc_out(pc_out),
-        .pc_next()
+        .pc_out(pc_out)
     );
     
     bram32 I_MEM(

--- a/cores/rv32i/src/sim/r_type_add_tb.v
+++ b/cores/rv32i/src/sim/r_type_add_tb.v
@@ -323,7 +323,7 @@ module r_type_add_tb(
         // Loading data into data BRAM
         $readmemh({`RISCV_PROGRAMS, "r_type/add_instruction_test_data.hex"}, init_mem_data);
         // Loading program into instruction BRAM
-        $readmemh({`RISCV_PROGRAMS, "add_instruction_test.new.hex"}, init_mem_instr);
+        $readmemh({`RISCV_PROGRAMS, "r_type/add_instruction_test.new.hex"}, init_mem_instr);
         
         // Deassert reset and initialize data BRAM
         rst = 1'b0; 

--- a/cores/rv32i/src/sim/self_dep_add_hazard_trigger_tb.v
+++ b/cores/rv32i/src/sim/self_dep_add_hazard_trigger_tb.v
@@ -68,6 +68,7 @@ module self_dep_add_hazard_trigger_tb(
         .w_addr(i_w_addr),
         .w_dat(i_w_dat),
         .w_enb(i_w_enb),
+        .byte_enb(4'b1111),
         // Read ports inputs
         .r_addr(pc_out),
         .r_enb(i_r_enb),
@@ -185,6 +186,7 @@ module self_dep_add_hazard_trigger_tb(
         .w_addr(d_bram_init_done ? alu_results : d_w_addr),
         .w_dat(d_bram_init_done  ? rs2         : d_w_dat),
         .w_enb(d_bram_init_done  ? mem_write   : d_w_enb),
+        .byte_enb(4'b1111),
         // Read ports inputs
         .r_addr(alu_results),
         .r_enb(mem_read), 
@@ -249,9 +251,9 @@ module self_dep_add_hazard_trigger_tb(
         #10;
         
         // Loading data into data BRAM
-        $readmemh("self_dep_test_data.hex", init_mem_data);
+        $readmemh({`RISCV_PROGRAMS, "hazards/self_dep_test_data.hex"}, init_mem_data);
         // Loading program into instruction BRAM
-        $readmemh("self_dep_add_test.new.hex", init_mem_instr);
+        $readmemh({`RISCV_PROGRAMS, "hazards/self_dep_add_test.new.hex"}, init_mem_instr);
         
         // Deassert reset and initialize data BRAM
         rst = 1'b0; 

--- a/cores/rv32i/src/sim/self_dep_add_hazard_trigger_tb.v
+++ b/cores/rv32i/src/sim/self_dep_add_hazard_trigger_tb.v
@@ -57,8 +57,7 @@ module self_dep_add_hazard_trigger_tb(
         .stall(pc_stall),
         .pc_select(1'b0),
         .pc_in(`BOOT_ADDR),
-        .pc_out(pc_out),
-        .pc_next()
+        .pc_out(pc_out)
     );
     
     wire [`DATA_WIDTH-1:0] instruction;

--- a/cores/rv32i/src/sim/self_dep_hazard_trigger_tb.v
+++ b/cores/rv32i/src/sim/self_dep_hazard_trigger_tb.v
@@ -66,6 +66,7 @@ module self_dep_hazard_trigger_tb(
         .w_addr(i_w_addr),
         .w_dat(i_w_dat),
         .w_enb(i_w_enb),
+        .byte_enb(4'b1111),
         // Read ports inputs
         .r_addr(pc_out),
         .r_enb(i_r_enb),
@@ -183,6 +184,7 @@ module self_dep_hazard_trigger_tb(
         .w_addr(d_bram_init_done ? alu_results : d_w_addr),
         .w_dat(d_bram_init_done  ? rs2         : d_w_dat),
         .w_enb(d_bram_init_done  ? mem_write   : d_w_enb),
+        .byte_enb(4'b1111),
         // Read ports inputs
         .r_addr(alu_results),
         .r_enb(mem_read), 
@@ -247,9 +249,9 @@ module self_dep_hazard_trigger_tb(
         #10;
         
         // Loading data into data BRAM
-        $readmemh("self_dep_test_data.hex", init_mem_data);
+        $readmemh({`RISCV_PROGRAMS, "hazards/self_dep_test_data.hex"}, init_mem_data);
         // Loading program into instruction BRAM
-        $readmemh("self_dep_test.new.hex", init_mem_instr);
+        $readmemh({`RISCV_PROGRAMS, "hazards/self_dep_test.new.hex"}, init_mem_instr);
         
         // Deassert reset and initialize data BRAM
         rst = 1'b0; 

--- a/cores/rv32i/src/sim/self_dep_hazard_trigger_tb.v
+++ b/cores/rv32i/src/sim/self_dep_hazard_trigger_tb.v
@@ -55,8 +55,7 @@ module self_dep_hazard_trigger_tb(
         .stall(pc_stall),
         .pc_select(1'b0),
         .pc_in(`BOOT_ADDR),
-        .pc_out(pc_out),
-        .pc_next()
+        .pc_out(pc_out)
     );
     
     wire [`DATA_WIDTH-1:0] instruction;

--- a/cores/rv32i/src/sim/shift_instructions_tb.v
+++ b/cores/rv32i/src/sim/shift_instructions_tb.v
@@ -117,7 +117,7 @@ module shift_instructions_tb(
         .alu_src(alu_src),
         .reg_write(reg_write),
         .wrt_back_src(wrt_back_src),
-        .second_u_type_add_src(second_u_type_add_src)
+        .second_add_src(second_u_type_add_src)
     );
     
     // Register file


### PR DESCRIPTION
[This MR contains the changes from #3]

Extends the Makefile to be able to run the simulations with iverilog instead of Vivado xsim. This is not only more portable (does not require Vivado installation) but also runs orders of magnitude faster (around 70ms instead of 30s per testbench).

To run individual testbenches:
- `make b_type_beq_bne_tb` to run with iverilog
- `make sim-vivado TB="b_type_beq_bne_tb"` to run with verilog

To run all testbenches:
- `make sim` to run with iverilog
- `make sim-vivado` to run with vivado